### PR TITLE
Use IJunctionRestrictionsHook instead of patching

### DIFF
--- a/NodeControllerRenewal/Manager/Extensions/SerializableDataExtension.cs
+++ b/NodeControllerRenewal/Manager/Extensions/SerializableDataExtension.cs
@@ -31,7 +31,7 @@ namespace NodeController
                 SingletonMod<Mod>.Logger.Debug($"Import NC2 data");
 
                 WasImported = true;
-                var state = Backward—ompatibility.Loader.Load<Backward—ompatibility.NCState>(data);
+                var state = BackwardCompatibility.Loader.Load<BackwardCompatibility.NCState>(data);
                 var config = state.ToXml();
                 SetLoadData(config);
             }

--- a/NodeControllerRenewal/Manager/SegmentEndData.cs
+++ b/NodeControllerRenewal/Manager/SegmentEndData.cs
@@ -765,7 +765,7 @@ namespace NodeController
         {
             var data = SingletonManager<Manager>.Instance[NodeId];
 
-            Render—ontour(contourData);
+            RenderContour(contourData);
             if (data.IsMoveableEnds && IsChangeable)
             {
                 RenderEnd(contourData, LengthXZ(LeftSide.Position - Position) + CircleRadius, 0f);
@@ -788,7 +788,7 @@ namespace NodeController
         }
         public void RenderAlign(OverlayData contourData, OverlayData? leftData = null, OverlayData? rightData = null)
         {
-            Render—ontour(contourData);
+            RenderContour(contourData);
             RenderEnd(contourData);
 
             if (leftData != null)
@@ -813,7 +813,7 @@ namespace NodeController
             line = line.Cut(startT, 1 - endT);
             line.Render(data);
         }
-        public void Render—ontour(OverlayData data)
+        public void RenderContour(OverlayData data)
         {
             RenderSide(LeftSide, data);
             RenderSide(RightSide, data);

--- a/NodeControllerRenewal/Mod.cs
+++ b/NodeControllerRenewal/Mod.cs
@@ -335,13 +335,12 @@ namespace NodeController
 
         private void PatchTMPE(ref bool success)
         {
+            var jrHook = TrafficManager.API.Implementations.HookFactory.JunctionRestrictionsHook;
+
+            jrHook.GetConfigurableHook += ExternalModPatches.GetConfigurableHook;
+            jrHook.GetDefaultsHook += ExternalModPatches.GetDefaultsHook;
+
             success &= Patch_TrafficLightManager_CanToggleTrafficLight();
-            success &= Patch_JunctionRestrictionsManager_GetDefaultEnteringBlockedJunctionAllowed();
-            success &= Patch_JunctionRestrictionsManager_GetDefaultPedestrianCrossingAllowed();
-            success &= Patch_JunctionRestrictionsManager_GetDefaultUturnAllowed();
-            success &= Patch_JunctionRestrictionsManager_IsEnteringBlockedJunctionAllowedConfigurable();
-            success &= Patch_JunctionRestrictionsManager_IsPedestrianCrossingAllowedConfigurable();
-            success &= Patch_JunctionRestrictionsManager_IsUturnAllowedConfigurable();
 
             if ((Type.GetType("TrafficManager.TrafficManagerMod") ?? Type.GetType("TrafficManager.Lifecycle.TrafficManagerMod")) is Type tmpeMod)
             {
@@ -359,30 +358,6 @@ namespace NodeController
         private bool Patch_TrafficLightManager_CanToggleTrafficLight()
         {
             return AddPrefix(typeof(ExternalModPatches), nameof(ExternalModPatches.CanToggleTrafficLightPrefix), typeof(TrafficLightManager), nameof(TrafficLightManager.CanToggleTrafficLight));
-        }
-        private bool Patch_JunctionRestrictionsManager_GetDefaultEnteringBlockedJunctionAllowed()
-        {
-            return AddPrefix(typeof(ExternalModPatches), nameof(ExternalModPatches.GetDefaultEnteringBlockedJunctionAllowedPrefix), typeof(JunctionRestrictionsManager), nameof(JunctionRestrictionsManager.GetDefaultEnteringBlockedJunctionAllowed));
-        }
-        private bool Patch_JunctionRestrictionsManager_GetDefaultPedestrianCrossingAllowed()
-        {
-            return AddPrefix(typeof(ExternalModPatches), nameof(ExternalModPatches.GetDefaultPedestrianCrossingAllowedPrefix), typeof(JunctionRestrictionsManager), nameof(JunctionRestrictionsManager.GetDefaultPedestrianCrossingAllowed));
-        }
-        private bool Patch_JunctionRestrictionsManager_GetDefaultUturnAllowed()
-        {
-            return AddPrefix(typeof(ExternalModPatches), nameof(ExternalModPatches.GetDefaultUturnAllowedPrefix), typeof(JunctionRestrictionsManager), nameof(JunctionRestrictionsManager.GetDefaultUturnAllowed));
-        }
-        private bool Patch_JunctionRestrictionsManager_IsEnteringBlockedJunctionAllowedConfigurable()
-        {
-            return AddPrefix(typeof(ExternalModPatches), nameof(ExternalModPatches.IsEnteringBlockedJunctionAllowedConfigurablePrefix), typeof(JunctionRestrictionsManager), nameof(JunctionRestrictionsManager.IsEnteringBlockedJunctionAllowedConfigurable));
-        }
-        private bool Patch_JunctionRestrictionsManager_IsPedestrianCrossingAllowedConfigurable()
-        {
-            return AddPrefix(typeof(ExternalModPatches), nameof(ExternalModPatches.IsPedestrianCrossingAllowedConfigurablePrefix), typeof(JunctionRestrictionsManager), nameof(JunctionRestrictionsManager.IsPedestrianCrossingAllowedConfigurable));
-        }
-        private bool Patch_JunctionRestrictionsManager_IsUturnAllowedConfigurable()
-        {
-            return AddPrefix(typeof(ExternalModPatches), nameof(ExternalModPatches.IsUturnAllowedConfigurablePrefix), typeof(JunctionRestrictionsManager), nameof(JunctionRestrictionsManager.IsUturnAllowedConfigurable));
         }
 
         #endregion

--- a/NodeControllerRenewal/NodeControllerRenewal.csproj
+++ b/NodeControllerRenewal/NodeControllerRenewal.csproj
@@ -131,7 +131,7 @@
     <Compile Include="Manager\MainRoad.cs" />
     <Compile Include="UI\OptionPanel.cs" />
     <Compile Include="UI\SimpleMessageBox.cs" />
-    <Compile Include="Utilities\BackwardСompatibility.cs" />
+    <Compile Include="Utilities\BackwardCompatibility.cs" />
     <Compile Include="Manager\Extensions\LoadingExtension.cs" />
     <Compile Include="Manager\NodeType.cs" />
     <Compile Include="Manager\SegmentSide.cs" />
@@ -254,7 +254,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_BuildVersioningStyle="None.None.None.Increment" BuildVersion_BuildAction="Both" BuildVersion_StartDate="2000/1/1" BuildVersion_ConfigurationName="Beta Debug" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" />
+      <UserProperties BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_ConfigurationName="Beta Debug" BuildVersion_StartDate="2000/1/1" BuildVersion_BuildAction="Both" BuildVersion_BuildVersioningStyle="None.None.None.Increment" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup Condition="'$(Configuration)' == 'Stable Release' OR '$(Configuration)' == 'Stable Debug'">

--- a/NodeControllerRenewal/ToolModes/AlignSegmentEnds.cs
+++ b/NodeControllerRenewal/ToolModes/AlignSegmentEnds.cs
@@ -167,7 +167,7 @@ namespace NodeController
             foreach (var segmentData in Tool.Data.SegmentEndDatas)
             {
                 var defaultColor = new OverlayData(cameraInfo) { Color = segmentData.OverlayColor, RenderLimit = underground };
-                segmentData.RenderСontour(defaultColor);
+                segmentData.RenderContour(defaultColor);
                 segmentData.RenderEnd(defaultColor);
             }
 

--- a/NodeControllerRenewal/ToolModes/DragCorner.cs
+++ b/NodeControllerRenewal/ToolModes/DragCorner.cs
@@ -50,7 +50,7 @@ namespace NodeController
             var forbidden = new OverlayData(cameraInfo) { Color = Colors.Red, RenderLimit = underground };
 
             SegmentEnd[Corner].Render(allow, forbidden, allow);
-            SegmentEnd.RenderСontour(new OverlayData(cameraInfo) { Color = SegmentEnd.OverlayColor, RenderLimit = underground });
+            SegmentEnd.RenderContour(new OverlayData(cameraInfo) { Color = SegmentEnd.OverlayColor, RenderLimit = underground });
             SegmentEnd.RenderEnd(new OverlayData(cameraInfo) { Color = SegmentEnd.OverlayColor, RenderLimit = underground });
             SegmentEnd[Corner].RenderCircle(new OverlayData(cameraInfo) { Color = Colors.Yellow, RenderLimit = underground });
         }

--- a/NodeControllerRenewal/Utilities/BackwardCompatibility.cs
+++ b/NodeControllerRenewal/Utilities/BackwardCompatibility.cs
@@ -10,7 +10,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Xml.Linq;
 using UnityEngine;
 
-namespace NodeController.BackwardСompatibility
+namespace NodeController.BackwardCompatibility
 {
     public static class Loader
     {


### PR DESCRIPTION
This eliminates NCR's patches to the `JunctionRestrictionsMangager` class, so that we can remove redundant deprecated methods without breaking NCR. It is currently a draft PR and cannot be merged until TMPE's planned `IJunctionRestrictionsHook` API is released to stable. Right now it can be tested by building TMPE from the following branch: https://github.com/Elesbaan70/TMPE/tree/junction-restrictions-hook

Note that this PR includes #54 because the project would not build on English-language systems without that change.